### PR TITLE
[Bugfix] psycopg2 is busted on newer version of python (3.7), so switch to psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 requires = [
     'django',
-    'psycopg2',
+    'psycopg2-binary',
 ]
 
 

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,3 +1,3 @@
-psycopg2>=2.7
+psycopg2-binary>=2.7
 pytest
 mock>=2.0


### PR DESCRIPTION
if you run the plain python 3.7 image from docker hub, installing this package fails.
`docker run -it python:3.7.3-slim-stretch /bin/sh`

<img width="911" alt="Screenshot 2019-07-11 15 13 17" src="https://user-images.githubusercontent.com/1268088/61089019-a3f81800-a3ee-11e9-8d25-732ba1688cea.png">
